### PR TITLE
Refactor backup_and_transfer.sh to streamline file copying

### DIFF
--- a/backup_and_transfer.sh
+++ b/backup_and_transfer.sh
@@ -2,24 +2,14 @@
 
 # Define paths
 CODE_PUBLIC_PATH="./code/public"
-PUBLIC_BACKUP_PATH="./public_backup"
 PUBLIC_PATH="./public"
 
-# Step 1: Create the public_backup folder if it doesn't exist
-if [ ! -d "$PUBLIC_BACKUP_PATH" ]; then
-  mkdir -p "$PUBLIC_BACKUP_PATH"
-  echo "Created backup folder: $PUBLIC_BACKUP_PATH"
-fi
-
-# Step 2: Copy all files from code/public to public_backup
-cp -r "$CODE_PUBLIC_PATH/"* "$PUBLIC_BACKUP_PATH/"
-echo "Copied files from $CODE_PUBLIC_PATH to $PUBLIC_BACKUP_PATH"
-
-# Step 3: Copy new files into the existing public folder without removing it
+# Step 1: Ensure the public folder exists
 if [ ! -d "$PUBLIC_PATH" ]; then
   mkdir -p "$PUBLIC_PATH"
   echo "Created public folder: $PUBLIC_PATH"
 fi
 
+# Step 2: Copy new files into the existing public folder without removing it
 cp -r "$CODE_PUBLIC_PATH/"* "$PUBLIC_PATH/"
 echo "Copied new files to $PUBLIC_PATH"


### PR DESCRIPTION
Remove the creation of a public_backup folder and directly copy new files to the existing public folder, simplifying the backup process.