### PR TITLE
Add backup step for public directory in Dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,9 @@
 # Use Node.js official image
 FROM node:18
 
+# Backup the code/public directory as public_backup before cleanup
+RUN mkdir -p /app/public_backup && [ -d /app/code/public ] && cp -r /app/code/public/* /app/public_backup || true
+
 # Install dependencies required by Puppeteer
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
Introduce a backup step for the public directory in the Dockerfile to ensure data preservation before cleanup.