### PR TITLE
Add image upload functionality to purchase controller and refactor

### DIFF
--- a/app/controllers/superadmin/purchase.controller.js
+++ b/app/controllers/superadmin/purchase.controller.js
@@ -1172,6 +1172,16 @@ exports.pre_store = async (req, res) => {
     //return false;
     let req_data = data; //JSON.stringify(data);
     //req_data = new Buffer.from(req_data).toString("base64");
+    
+    let image_path = await base64FileUpload(
+      data.current_image,
+      "products",
+    );
+
+    data.current_image = image_path.path;
+
+    console.log("pre purchase store payload after image upload : ", data.current_image);
+    
     req_data = encodeForStorage(req_data);  
     let prePurchaseObj = {
       user_id: userID,


### PR DESCRIPTION
This pull request updates the `pre_store` controller to handle image uploads for product purchases. Now, when a new purchase is being stored, the image data is uploaded and the resulting file path is saved in the purchase data before storage.

**Image upload integration:**

* Added logic to upload the `current_image` using `base64FileUpload`, store the resulting file path in `data.current_image`, and log the path for debugging. (`app/controllers/superadmin/purchase.controller.js`)